### PR TITLE
fix stat src/coordinator: no such file or directory

### DIFF
--- a/contrib/docker-start.sh
+++ b/contrib/docker-start.sh
@@ -2,4 +2,4 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # Make the docker image and tag it as "firmament"
-docker run --expose=8080 --workdir=/firmament firmament src/coordinator --flagfile=/firmament/default.conf
+docker run --expose=8080 --workdir=/firmament firmament build/src/coordinator --flagfile=/firmament/default.conf


### PR DESCRIPTION
```bash
~/firmament# docker run --expose=8080 --workdir=/firmament firmament src/coordinator --flagfile=/firmament/default.conf

container_linux.go:247: starting container process caused "exec: \"src/coordinator\": stat src/coordinator: no such file or directory"
docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"src/coordinator\": stat src/coordinator: no such file or directory".
```

need to specify the right destination where the binary locates