### PR TITLE
refine job submit cmake list, resolve python import error

### DIFF
--- a/scripts/job/CMakeLists.txt
+++ b/scripts/job/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(JOB_SUBMIT_PROTOBUFS
+  ${Firmament_SOURCE_DIR}/base/label.proto
+  ${Firmament_SOURCE_DIR}/base/label_selector.proto
   ${Firmament_SOURCE_DIR}/base/job_desc.proto
   ${Firmament_SOURCE_DIR}/base/task_desc.proto
   ${Firmament_SOURCE_DIR}/base/reference_desc.proto


### PR DESCRIPTION
python job_submit.py <host> <webUI port (8080)> <binary>

would throw some proto class not found error, such as:
```bash
ImportError: cannot import name label_pb2
ImportError: cannot import name label_selector_pb2
```
this pr refine the cmake list to resolve that issue