### PR TITLE
added some cleanup tweaks

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -2,8 +2,15 @@ FROM ubuntu:16.04
 MAINTAINER firmament-dev@camsas.org
 
 RUN apt-get -y update
-RUN apt-get -y install git-core build-essential make && git clone https://github.com/camsas/firmament /firmament
-RUN bash -c 'source /firmament/include/pkglist.Ubuntu-16.04 && apt-get -y install ${BASE_PKGS} ${COMPILER_PKGS} ${GOOGLE_PKGS} ${BOOST_PKGS} ${MISC_PKGS} ${HDFS_PKGS} ${PION_PKGS}'
+RUN apt-get --no-install-recommends -y install git-core build-essential make && git clone https://github.com/camsas/firmament /firmament
+RUN bash -c 'source /firmament/include/pkglist.Ubuntu-16.04 && apt-get --no-install-recommends -y install ${BASE_PKGS} ${COMPILER_PKGS} ${GOOGLE_PKGS} ${BOOST_PKGS} ${MISC_PKGS} ${HDFS_PKGS} ${PION_PKGS}'
 RUN mkdir /var/log/firmament && cd /firmament && make && cd build && make -j12
 COPY firmament-default.conf /firmament/default.conf
-RUN apt-get clean
+RUN apt-get clean \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/* \
+        /var/tmp/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at Ubuntu Blog .

Another Cleanup tweaks using

apt-get clean

rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

removing downloaded packages and packages list will free up some space ,

results in smaller image size.